### PR TITLE
Fixed Next and Previous Button not showing

### DIFF
--- a/Classes/Fusion/PaginationArrayImplementation.php
+++ b/Classes/Fusion/PaginationArrayImplementation.php
@@ -143,11 +143,11 @@ class PaginationArrayImplementation extends AbstractFusionObject
         }
         // add previous and next
         if ($this->paginationConfig['showNextAndPrevious']) {
-            if ($this->firstPage > 1 || $this->paginationConfig['alwaysShowNextAndPrevious']) {
+            if ($this->currentPage > 1 || $this->paginationConfig['alwaysShowNextAndPrevious']) {
                 $pageArray = $this->addItemToTheStartOfPageArray($pageArray, $this->currentPage - 1, 'previous');
             }
-            if ($this->lastPage  < $this->numberOfPages || $this->paginationConfig['alwaysShowNextAndPrevious']) {
-                if($this->currentPage < $this->numberOfPages) {
+            if ($this->currentPage  < $this->lastPage || $this->paginationConfig['alwaysShowNextAndPrevious']) {
+                if ($this->currentPage < $this->numberOfPages) {
                     $pageArray = $this->addItemToTheEndOfPageArray($pageArray, $this->currentPage + 1, 'next');
                 } else {
                     $pageArray = $this->addItemToTheEndOfPageArray($pageArray, $this->currentPage, 'next');


### PR DESCRIPTION
Currently the Next and Previous buttons are only shown, if you set 'alwaysShowNextAndPrevious' to true. This is because the conditions `$this->firstPage > 1`  and `$this->lastPage  < $this->numberOfPages` are never true.
This pull request fixes the conditions.